### PR TITLE
Filter exclusiveMaximum and exclusiveMinimum

### DIFF
--- a/src/wrapField.tsx
+++ b/src/wrapField.tsx
@@ -9,10 +9,12 @@ declare module 'uniforms' {
     autoValue: never;
     isDisabled: never;
     checkboxes: never;
+    exclusiveMaximum: never;
+    exclusiveMinimum: never;
   }
 }
 
-filterDOMProps.register('decimal', 'minCount', 'autoValue', 'isDisabled');
+filterDOMProps.register('decimal', 'minCount', 'autoValue', 'isDisabled', 'exclusiveMaximum', 'exclusiveMinimum');
 
 type WrapperProps = {
   id: string;


### PR DESCRIPTION
I'm working with some schemas that contains the `exclusiveMaximum` and `exclusiveMinimum` properties. Adding those properties to the filter removes some error logs because they are not properties of the `FormGroup` component.