### PR TITLE
Make PatternFly a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@babel/preset-env": "7.11.0",
     "@babel/preset-react": "7.10.4",
     "@babel/preset-typescript": "7.10.4",
+    "@patternfly/react-core": "4.101.3",
+    "@patternfly/react-icons": "4.9.5",
     "@testing-library/react": "10.4.9",
     "@types/classnames": "2.2.11",
     "@types/enzyme": "3.10.8",
@@ -66,7 +68,7 @@
     "uniforms": "3.0.0",
     "uniforms-bridge-simple-schema-2": "3.0.0"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@patternfly/react-core": "4.101.3",
     "@patternfly/react-icons": "4.9.5"
   },


### PR DESCRIPTION
PatternFly is listed as a direct dependency, which can lead to multiple versions of PatternFly being used by a project that depends on uniforms-patternfly.

By declaring it as a peer dependency fixes this. 