### PR TITLE
Improvements on TextField and DateField components

### DIFF
--- a/__tests__/DateField.tsx
+++ b/__tests__/DateField.tsx
@@ -88,17 +88,10 @@ test('<DateField> - renders a input with correct value (model)', () => {
     createContext({ x: { type: Date } }, { model: { x: now } })
   );
 
-  let isAm = true;
-  let hours = now.getHours();
-  if (hours > 12) {
-    hours %= 12;
-    isAm = false;
-  }
-  const minutes = now.getMinutes();
-  const time = `${hours}:${minutes} ${isAm ? 'AM' : 'PM'}`;
-
   expect(wrapper.find('input')).toHaveLength(2);
-  expect(wrapper.find('TimePicker').prop('value')).toEqual(time);
+  expect(wrapper.find('TimePicker').prop('value')).toEqual(
+    `${now.getUTCHours()}:${now.getUTCMinutes()}`
+  );
 });
 
 test('<DateField> - renders a input with correct value (specified)', () => {
@@ -128,7 +121,7 @@ test('<DateField> - renders a input which correctly reacts on change (DatePicker
     } as any);
   });
 
-  expect(onChange).toHaveBeenLastCalledWith('x', new Date(`${now}T00:00:00`));
+  expect(onChange).toHaveBeenLastCalledWith('x', new Date(`${now}T00:00:00Z`));
 });
 
 test('<DateField> - renders a input which correctly reacts on change (DatePicker - empty)', () => {
@@ -152,7 +145,7 @@ test('<DateField> - renders a input which correctly reacts on change (DatePicker
 test('<DateField> - renders a input which correctly reacts on change (TimePicker - invalid)', () => {
   const onChange = jest.fn();
 
-  const now = '10:00 AM';
+  const now = '10:00';
   const element = <DateField name="x" />;
   const wrapper = mount(
     element,
@@ -168,12 +161,12 @@ test('<DateField> - renders a input which correctly reacts on change (TimePicker
   expect(onChange).not.toHaveBeenCalled();
 });
 
-test.skip('<DateField> - renders a input which correctly reacts on change (TimePicker - valid)', () => {
+test('<DateField> - renders a input which correctly reacts on change (TimePicker - valid)', () => {
   const onChange = jest.fn();
 
   const date = '2000-04-04';
-  const time = '10:30 AM';
-  const element = <DateField name="x" value={new Date(`${date}T00:00:00`)} />;
+  const time = '10:30';
+  const element = <DateField name="x" value={new Date(`${date}T00:00:00Z`)} />;
   const wrapper = mount(
     element,
     createContext({ x: { type: Date } }, { onChange })
@@ -185,7 +178,7 @@ test.skip('<DateField> - renders a input which correctly reacts on change (TimeP
     } as any);
   });
 
-  expect(onChange).toHaveBeenLastCalledWith('x', new Date(`${date}T10:30:00`));
+  expect(onChange).toHaveBeenLastCalledWith('x', new Date(`${date}T10:30:00Z`));
 });
 
 test('<DateField> - renders a wrapper with unknown props', () => {
@@ -195,4 +188,68 @@ test('<DateField> - renders a wrapper with unknown props', () => {
   expect(wrapper.find('div').at(0).prop('data-x')).toBe('x');
   expect(wrapper.find('div').at(0).prop('data-y')).toBe('y');
   expect(wrapper.find('div').at(0).prop('data-z')).toBe('z');
+});
+
+test('<DateField> - test max property - valid', () => {
+  const onChange = jest.fn();
+
+  const date = '1998-12-31';
+  const max = '1999-01-01T00:00:00Z';
+  const element = (
+    <DateField name="x" max={max} value={new Date(`${date}T00:00:00Z`)} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: Date } }, { onChange })
+  );
+
+  expect(wrapper.text().includes('Should be before')).toBe(false);
+});
+
+test('<DateField> - test max property - invalid', () => {
+  const onChange = jest.fn();
+
+  const date = '1999-01-02';
+  const max = '1999-01-01T00:00:00Z';
+  const element = (
+    <DateField name="x" max={max} value={new Date(`${date}T00:00:00Z`)} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: Date } }, { onChange })
+  );
+
+  expect(wrapper.text().includes('Should be before')).toBe(true);
+});
+
+test('<DateField> - test min property - valid', () => {
+  const onChange = jest.fn();
+
+  const date = '1999-01-02';
+  const min = '1999-01-01T00:00:00Z';
+  const element = (
+    <DateField name="x" min={min} value={new Date(`${date}T00:00:00Z`)} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: Date } }, { onChange })
+  );
+
+  expect(wrapper.text().includes('Should be after')).toBe(false);
+});
+
+test('<DateField> - test min property - invalid', () => {
+  const onChange = jest.fn();
+
+  const date = '1998-12-31';
+  const min = '1999-01-01T00:00:00Z';
+  const element = (
+    <DateField name="x" min={min} value={new Date(`${date}T00:00:00Z`)} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: Date } }, { onChange })
+  );
+
+  expect(wrapper.text().includes('Should be after')).toBe(true);
 });

--- a/__tests__/TextField.tsx
+++ b/__tests__/TextField.tsx
@@ -243,3 +243,80 @@ test('<TextField> - renders a input which correctly reacts on change (DatePicker
 
   expect(onChange).toHaveBeenLastCalledWith('x', date);
 });
+
+test('<TextField> - renders a initial value on time field (TimePicker)', () => {
+  const time = '10:00';
+  const element = (
+    <TextField required={true} name="x" label="y" type={'time'} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: String } }, { model: { x: time } })
+  );
+
+  expect(wrapper.find('TimePicker')).toHaveLength(1);
+  expect(wrapper.find('TimePicker').prop('value')).toBe(time);
+});
+
+test('<TextField> - renders a disabled date field (TimePicker)', () => {
+  const element = (
+    <TextField
+      required={true}
+      name="x"
+      label="y"
+      type={'time'}
+      disabled={true}
+    />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.find('TimePicker')).toHaveLength(1);
+  expect(wrapper.find('input').prop('disabled')).toBe(true);
+});
+
+test('<TextField> - renders a input which correctly reacts on change (TimePicker)', () => {
+  const onChange = jest.fn();
+
+  const time = '10:10';
+  const element = (
+    <TextField required={true} name="x" label="y" type={'time'} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: String } }, { onChange })
+  );
+
+  act(() => {
+    wrapper.find('TimePicker').find('input').prop('onChange')!({
+      currentTarget: { value: time },
+    } as any);
+  });
+
+  expect(wrapper.find('label')).toHaveLength(1);
+  expect(wrapper.find('label').text()).toBe('y *');
+  expect(onChange).toHaveBeenLastCalledWith('x', '10:10:00');
+});
+
+test('<TextField> - renders a input which correctly reacts on change (TimePicker - empty)', () => {
+  const onChange = jest.fn();
+
+  const time = '';
+  const element = (
+    <TextField required={true} name="x" label="y" type={'time'} />
+  );
+  const wrapper = mount(
+    element,
+    createContext({ x: { type: String } }, { onChange })
+  );
+
+  expect(wrapper.find('label')).toHaveLength(1);
+  expect(wrapper.find('label').text()).toBe('y *');
+
+  act(() => {
+    wrapper.find('TimePicker').find('input').prop('onChange')!({
+      currentTarget: { value: time },
+    } as any);
+  });
+
+  expect(onChange).toHaveBeenLastCalledWith('x', time);
+});

--- a/__tests__/TextField.tsx
+++ b/__tests__/TextField.tsx
@@ -320,3 +320,91 @@ test('<TextField> - renders a input which correctly reacts on change (TimePicker
 
   expect(onChange).toHaveBeenLastCalledWith('x', time);
 });
+
+test('<TextField> - test max property (TimePicker - valid)', () => {
+  const time = '10:00';
+  const max = '12:00';
+  const element = (
+    <TextField name="x" label="y" max={max} type={'time'} value={time} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be before')).toBe(false);
+});
+
+test('<TextField> - test max property (TimePicker - invalid)', () => {
+  const time = '13:00';
+  const max = '12:00';
+  const element = (
+    <TextField name="x" label="y" max={max} type={'time'} value={time} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be before')).toBe(true);
+});
+
+test('<TextField> - test min property (TimePicker - valid)', () => {
+  const time = '13:00';
+  const min = '12:00';
+  const element = (
+    <TextField name="x" label="y" min={min} type={'time'} value={time} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be after')).toBe(false);
+});
+
+test('<TextField> - test min property (TimePicker - invalid)', () => {
+  const time = '10:00';
+  const min = '12:00';
+  const element = (
+    <TextField name="x" label="y" min={min} type={'time'} value={time} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be after')).toBe(true);
+});
+
+test('<TextField> - test max property (DatePicker - valid)', () => {
+  const date = '2000-01-01';
+  const max = '2000-01-02';
+  const element = (
+    <TextField name="x" label="y" max={max} type={'date'} value={date} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be before')).toBe(false);
+});
+
+test('<TextField> - test max property (DatePicker - invalid)', () => {
+  const date = '2000-01-02';
+  const max = '2000-01-01';
+  const element = (
+    <TextField name="x" label="y" max={max} type={'date'} value={date} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be before')).toBe(true);
+});
+
+test('<TextField> - test min property (DatePicker - valid)', () => {
+  const date = '2000-01-02';
+  const min = '2000-01-01';
+  const element = (
+    <TextField name="x" label="y" min={min} type={'date'} value={date} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be after')).toBe(false);
+});
+
+test('<TextField> - test min property (DatePicker - invalid)', () => {
+  const date = '2000-01-01';
+  const min = '2000-01-02';
+  const element = (
+    <TextField name="x" label="y" min={min} type={'date'} value={date} />
+  );
+  const wrapper = mount(element, createContext({ x: { type: String } }));
+
+  expect(wrapper.text().includes('Should be after')).toBe(true);
+});

--- a/examples/package.json
+++ b/examples/package.json
@@ -7,8 +7,8 @@
     "start": "parcel serve  --no-cache index.html"
   },
   "dependencies": {
-    "@patternfly/react-core": "4.115.2",
-    "@patternfly/react-icons": "4.10.2",
+    "@patternfly/react-core": "4.135.0",
+    "@patternfly/react-icons": "4.11.0",
     "ajv": "6.10.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
@@ -19,7 +19,7 @@
     "uniforms-bridge-json-schema": "3.5.1",
     "uniforms-bridge-simple-schema": "3.5.1",
     "uniforms-bridge-simple-schema-2": "3.5.1",
-    "uniforms-patternfly": "4.6.1"
+    "uniforms-patternfly": "4.6.2"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.5",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "@babel/preset-env": "7.11.0",
     "@babel/preset-react": "7.10.4",
     "@babel/preset-typescript": "7.10.4",
-    "@patternfly/react-core": "4.115.2",
-    "@patternfly/react-icons": "4.10.2",
+    "@patternfly/react-core": "4.135.0",
+    "@patternfly/react-icons": "4.11.0",
     "@testing-library/react": "10.4.9",
     "@types/classnames": "2.2.11",
     "@types/enzyme": "3.10.8",
@@ -66,8 +66,8 @@
     "uniforms-bridge-simple-schema-2": "3.5.1"
   },
   "peerDependencies": {
-    "@patternfly/react-core": "^4.115.2",
-    "@patternfly/react-icons": "^4.10.2"
+    "@patternfly/react-core": "^4.135.0",
+    "@patternfly/react-icons": "^4.11.0"
   },
   "engines": {
     "npm": ">=5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-patternfly",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Patternfly forms for uniforms",
   "repository": "git@github.com:aerogear/uniforms-patternfly.git",
   "author": "Gianluca <gzuccare@redhat.com>",

--- a/src/DateField.tsx
+++ b/src/DateField.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useState } from 'react';
-import { connectField, FieldProps, filterDOMProps } from 'uniforms/es5';
+import React, { useCallback, useMemo } from 'react';
+import { connectField, FieldProps } from 'uniforms/es5';
 import {
   DatePicker,
   Flex,
@@ -16,26 +16,14 @@ export type DateFieldProps = FieldProps<
   TextInputProps,
   {
     inputRef: React.RefObject<HTMLInputElement>;
-    max?: Date;
-    min?: Date;
+    max?: string;
+    min?: string;
   }
 >;
 
 const DateConstructor = (typeof global === 'object' ? global : window).Date;
 
 function DateField(props: DateFieldProps) {
-  const validateDate = useCallback(
-    (date) => {
-      if (props.min && date < props.min) {
-        return props.errorMessage ?? `Should be bigger than ${props.min}`;
-      } else if (props.max && date > props.max) {
-        return props.errorMessage ?? `Should be smaller than ${props.max}`;
-      }
-      return '';
-    },
-    [props.max, props.min]
-  );
-
   const parseDate = useCallback(() => {
     if (!props.value) {
       return '';
@@ -47,15 +35,7 @@ function DateField(props: DateFieldProps) {
     if (!props.value) {
       return '';
     }
-
-    let isAm = true;
-    let hours = props.value.getHours();
-    if (hours > 12) {
-      hours %= 12;
-      isAm = false;
-    }
-    const minutes = props.value.getMinutes();
-    return `${hours}:${minutes} ${isAm ? 'AM' : 'PM'}`;
+    return `${props.value.getUTCHours()}:${props.value.getUTCMinutes()}`;
   }, [props.value]);
 
   const onDateChange = useCallback(
@@ -66,8 +46,11 @@ function DateField(props: DateFieldProps) {
         const newDate = new DateConstructor(date);
         const time = parseTime();
         if (time !== '') {
-          newDate.setHours(parseInt(time?.split(':')[0]));
-          newDate.setMinutes(parseInt(time?.split(':')[1]?.split(' ')[0]));
+          newDate.setUTCHours(parseInt(time?.split(':')[0]));
+          newDate.setUTCMinutes(parseInt(time?.split(':')[1]?.split(' ')[0]));
+        } else {
+          newDate.setUTCHours(0);
+          newDate.setUTCMinutes(0);
         }
         props.onChange(newDate);
       }
@@ -75,20 +58,45 @@ function DateField(props: DateFieldProps) {
     [props.onChange, parseTime]
   );
 
+  const isInvalid = useMemo(() => {
+    if (props.value) {
+      if (props.min) {
+        const minDate = new Date(props.min);
+        if (minDate.toString() === 'Invalid Date') {
+          return false;
+        } else if (props.value < minDate) {
+          return `Should be after ${minDate.toISOString()}`;
+        }
+      }
+      if (props.max) {
+        const maxDate = new Date(props.max);
+        if (maxDate.toString() === 'Invalid Date') {
+          return false;
+        } else if (props.value > maxDate) {
+          return `Should be before ${maxDate.toISOString()}`;
+        }
+      }
+    }
+    return false;
+  }, [props.value]);
+
   const onTimeChange = useCallback(
     (time: string, hours?: number, minutes?: number) => {
       if (props.value) {
         const newDate = new DateConstructor(props.value);
         if (hours && minutes) {
-          newDate.setHours(hours);
-          newDate.setMinutes(minutes);
+          newDate.setUTCHours(hours);
+          newDate.setUTCMinutes(minutes);
         } else if (time !== '') {
           const localeHours = parseInt(time?.split(':')[0]);
           const localeMinutes = parseInt(time?.split(':')[1]?.split(' ')[0]);
           if (!isNaN(localeHours) && !isNaN(localeMinutes)) {
-            newDate.setHours(localeHours);
-            newDate.setMinutes(localeMinutes);
+            newDate.setUTCHours(localeHours);
+            newDate.setUTCMinutes(localeMinutes);
           }
+        } else {
+          newDate.setUTCHours(0);
+          newDate.setUTCMinutes(0);
         }
         props.onChange(newDate);
       }
@@ -99,18 +107,18 @@ function DateField(props: DateFieldProps) {
   return wrapField(
     props,
     <Flex
+      style={{ margin: 0 }}
       direction={{ default: 'column' }}
       id={props.id}
       name={props.name}
       ref={props.inputRef}
     >
-      <FlexItem>
+      <FlexItem style={{ margin: 0 }}>
         <InputGroup style={{ background: 'transparent' }}>
           <DatePicker
             id={`date-picker-${props.id}`}
             data-testid={`date-picker`}
             isDisabled={props.disabled}
-            validators={[validateDate]}
             name={props.name}
             onChange={onDateChange}
             value={parseDate() ?? ''}
@@ -118,14 +126,26 @@ function DateField(props: DateFieldProps) {
           <TimePicker
             id={`time-picker-${props.id}`}
             data-testid={`time-picker`}
-            isDisabled={props.disabled}
+            isDisabled={props.disabled || !props.value}
             name={props.name}
             onChange={onTimeChange}
             style={{ width: '120px' }}
             value={parseTime() ?? ''}
+            is24Hour
           />
         </InputGroup>
       </FlexItem>
+      {isInvalid && (
+        <div
+          style={{
+            fontSize: '0.875rem',
+            color: '#c9190b',
+            marginTop: '0.25rem',
+          }}
+        >
+          {isInvalid}
+        </div>
+      )}
     </Flex>
   );
 }

--- a/src/DateField.tsx
+++ b/src/DateField.tsx
@@ -137,6 +137,7 @@ function DateField(props: DateFieldProps) {
       </FlexItem>
       {isInvalid && (
         <div
+          id={`${props.id}-invalid-date-time`}
           style={{
             fontSize: '0.875rem',
             color: '#c9190b',

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -1,5 +1,10 @@
 import React, { Ref, useCallback } from 'react';
-import { DatePicker, TextInput, TextInputProps } from '@patternfly/react-core';
+import {
+  DatePicker,
+  TextInput,
+  TextInputProps,
+  TimePicker,
+} from '@patternfly/react-core';
 import { connectField, filterDOMProps } from 'uniforms/es5';
 
 import wrapField from './wrapField';
@@ -29,9 +34,47 @@ const Text = (props: TextFieldProps) => {
     [props.max, props.min]
   );
 
+  const parseTime = useCallback((time: string) => {
+    const parsedTime = time.split(':').map((e) => parseInt(e, 10));
+    const date = new Date();
+    // @ts-ignore
+    date.setUTCHours(...parsedTime);
+    return date;
+  }, []);
+
+  const validateTime = useCallback(
+    (time: string) => {
+      if (typeof props.min === 'string' && typeof props.max === 'string') {
+        const parsedTime = parseTime(time);
+        const parsedMin = parseTime(props.min);
+        const parsedMax = parseTime(props.max);
+        if (parsedTime < parsedMin) {
+          return false;
+        }
+        if (parsedTime > parsedMax) {
+          return false;
+        }
+      }
+      return true;
+    },
+    [props.max, props.min]
+  );
+
   const onDateChange = useCallback(
     (value: string) => {
       props.onChange(value);
+    },
+    [props.disabled, props.onChange]
+  );
+
+  const onTimeChange = useCallback(
+    (time: string) => {
+      const parsedTime = time.split(':');
+      if (parsedTime.length === 2) {
+        props.onChange([...parsedTime, '00'].join(':'));
+      } else {
+        props.onChange(time);
+      }
     },
     [props.disabled, props.onChange]
   );
@@ -46,6 +89,15 @@ const Text = (props: TextFieldProps) => {
         onChange={onDateChange}
         value={props.value ?? ''}
         {...filterDOMProps(props)}
+      />
+    ) : props.type === 'time' || props.field?.format === 'time' ? (
+      <TimePicker
+        name={props.name}
+        isDisabled={props.disabled}
+        validateTime={validateTime}
+        onChange={onTimeChange}
+        is24Hour
+        value={props.value ?? ''}
       />
     ) : (
       <TextInput

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -24,10 +24,17 @@ export type TextFieldProps = {
 const Text = (props: TextFieldProps) => {
   const validateDate = useCallback(
     (date) => {
-      if (props.min && date < props.min) {
-        return props.errorMessage ?? `Should be bigger than ${props.min}`;
-      } else if (props.max && date > props.max) {
-        return props.errorMessage ?? `Should be smaller than ${props.max}`;
+      if (props.min && date.toISOString() < new Date(props.min).toISOString()) {
+        return props.errorMessage && props.errorMessage.trim().length > 0
+          ? props.errorMessage
+          : `Should be after than ${props.min}`;
+      } else if (
+        props.max &&
+        date.toISOString() > new Date(props.max).toISOString()
+      ) {
+        return props.errorMessage && props.errorMessage.trim().length > 0
+          ? props.errorMessage
+          : `Should be before than ${props.max}`;
       }
       return '';
     },

--- a/src/TextField.tsx
+++ b/src/TextField.tsx
@@ -24,12 +24,16 @@ export type TextFieldProps = {
 const timeRgx = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9])(:[0-5][0-9])?/;
 
 const Text = (props: TextFieldProps) => {
-  const validateDate = useCallback(
-    (date) => {
+  const isDateInvalid = useMemo(() => {
+    if (
+      typeof props.value === 'string' &&
+      (props.type === 'date' || props.field?.format === 'date')
+    ) {
+      const date = new Date(props.value);
       if (typeof props.min === 'string') {
         const minDate = new Date(props.min);
         if (minDate.toString() === 'Invalid Date') {
-          return '';
+          return false;
         } else if (date.toISOString() < minDate.toISOString()) {
           return props.errorMessage && props.errorMessage.trim().length > 0
             ? props.errorMessage
@@ -39,17 +43,16 @@ const Text = (props: TextFieldProps) => {
       if (typeof props.max === 'string') {
         const maxDate = new Date(props.max);
         if (maxDate.toString() === 'Invalid Date') {
-          return '';
+          return false;
         } else if (date.toISOString() > maxDate.toISOString()) {
           return props.errorMessage && props.errorMessage.trim().length > 0
             ? props.errorMessage
             : `Should be before ${props.max}`;
         }
       }
-      return '';
-    },
-    [props.max, props.min, props.errorMessage]
-  );
+    }
+    return false;
+  }, [props.value, props.max, props.min, props.errorMessage]);
 
   const parseTime = useCallback((time: string) => {
     const parsedTime = timeRgx.exec(time);
@@ -114,14 +117,26 @@ const Text = (props: TextFieldProps) => {
   return wrapField(
     props,
     props.type === 'date' || props.field?.format === 'date' ? (
-      <DatePicker
-        name={props.name}
-        isDisabled={props.disabled}
-        validators={[validateDate]}
-        onChange={onDateChange}
-        value={props.value ?? ''}
-        {...filterDOMProps(props)}
-      />
+      <>
+        <DatePicker
+          name={props.name}
+          isDisabled={props.disabled}
+          onChange={onDateChange}
+          value={props.value ?? ''}
+          {...filterDOMProps(props)}
+        />
+        {isDateInvalid && (
+          <div
+            style={{
+              fontSize: '0.875rem',
+              color: '#c9190b',
+              marginTop: '0.25rem',
+            }}
+          >
+            {isDateInvalid}
+          </div>
+        )}
+      </>
     ) : props.type === 'time' || props.field?.format === 'time' ? (
       <>
         <TimePicker

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "baseUrl": ".",
     "rootDir": "./src/",
     "outDir": "./dist/",
-    "composite": true,
     "declaration": true,
     "esModuleInterop": true,
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "baseUrl": ".",
     "rootDir": "./src/",
     "outDir": "./dist/",
+    "composite": true,
     "declaration": true,
     "esModuleInterop": true,
     "importHelpers": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,38 +1153,33 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@patternfly/react-core@4.115.2":
-  version "4.115.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.115.2.tgz#084d1e408463945fa94f2b3bed13bd0b1146dcae"
-  integrity sha512-lnA+WmTQ0IyJIuSSUH0mjMUujAb6sYGNFMwkGDy4BpJjeu0aredVEmM0kAe/rFAurjSen/JpOhET2V3NiMGKtA==
+"@patternfly/react-core@4.135.0":
+  version "4.135.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.135.0.tgz#b64ad4da10a8814926e28fad727bc7690cd60e66"
+  integrity sha512-DZcONUGOR7Znd6BsUJ4L+KrrnIpyjUvh3JNcYiHW3loytxShCGcx+a04QjOOcZm+MtFhkgs/t51yiC5IP12abA==
   dependencies:
-    "@patternfly/react-icons" "^4.10.2"
-    "@patternfly/react-styles" "^4.10.2"
-    "@patternfly/react-tokens" "^4.11.3"
+    "@patternfly/react-icons" "^4.11.0"
+    "@patternfly/react-styles" "^4.11.0"
+    "@patternfly/react-tokens" "^4.12.0"
     focus-trap "6.2.2"
     react-dropzone "9.0.0"
     tippy.js "5.1.2"
     tslib "1.13.0"
 
-"@patternfly/react-icons@4.10.2":
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.10.2.tgz#d0659e7763364b1e73ec0f3b60e20cf9e4f067d6"
-  integrity sha512-mSkBRaEFukpaAoLDyd3nI+6Cj0z2/5DgJTA2i7By/UW1wJifKnBWW8NRO2SsJQVQIUtuuAunjUrjzKHdcxs5IQ==
+"@patternfly/react-icons@4.11.0", "@patternfly/react-icons@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.11.0.tgz#26790eeff22dc3204aa8cd094470f0a2f915634a"
+  integrity sha512-WsIX34bO9rhVRmPG0jlV3GoFGfYgPC64TscNV0lxQosiVRnYIA6Z3nBSArtJsxo5Yn6c63glIefC/YTy6D/ZYg==
 
-"@patternfly/react-icons@^4.10.2":
-  version "4.10.11"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.10.11.tgz#9bed483fc37c8b795b3fb98c17ede00eef775857"
-  integrity sha512-Qyxwvghb9HZB2do3UVw4EzJSvqWaw/AEw6mFzqshZiIm2oPrL4NkvavwDt5WRicz5sbyWTZluB4grOj33PEpww==
+"@patternfly/react-styles@^4.11.0":
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.11.0.tgz#0068dcb18e1343242f93fa6024dcc077acd57fb9"
+  integrity sha512-4eIqTwGI4mjt9DMqX6hnan4eRS+3LUWNaneTEJdmk+flKxtAE/O/OmQHvH4GetDnlSbyfATcA0VFbVtR0aRJAg==
 
-"@patternfly/react-styles@^4.10.2":
-  version "4.10.11"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.10.11.tgz#6bda5673a71037c0fb9be7e11a117ed8cfea6ce0"
-  integrity sha512-M+NhTtAXreJzMAV2Z1P2pbnKpRYnWbB5iZ6mxB0tkxxG+KyZ0/se8M5rUepLOE/n7BMq8IiOjPJ9zu/vpWj0gA==
-
-"@patternfly/react-tokens@^4.11.3":
-  version "4.11.12"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.11.12.tgz#0d4d88ec768cbf5c4b46e75dc8673ba97448823c"
-  integrity sha512-PTEc2CQa/BqcDcUwT0V02l+ZoJa+bheLlh9R5g1+JQ6vlqH31gk0dpHmj6goEcSDLkbvMJgr3kNZdJsP1VdBMg==
+"@patternfly/react-tokens@^4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.12.0.tgz#2973c7f08a2f35997a0054bbf3c886b3c5c68822"
+  integrity sha512-Oj+GxqTtx0Yu9IDCTibZLQnpcKp58JneNKEFQkJ29WJydhPG4j6oFFElkK+ub+Ft/f9B1Ky1SsfR9eabo6IykQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"


### PR DESCRIPTION
- Update the `TextField` component to render a specific `TimePicker` component when the field type is `time`;
- Update `TextField` validations of `max/min` props;
- Update `DateField` validations of `max/min` props;
- Fix a bug on the `DateField` component when time was selected before the date. Now, time is disabled without a date.
- Add new tests and update older tests (remove a skip);
- Update Patternfly version;