### PR TITLE
chore: update the build process to align to uniforms upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,17 @@
   "author": "Gianluca <gzuccare@redhat.com>",
   "license": "Apache-2.0",
   "main": "dist/es5/index.js",
-  "module": "dist/es6/index.js",
+  "module": "dist/esm/index.js",
+  "files": [
+    "dist/es5/*.d.ts",
+    "dist/es5/*.js",
+    "dist/esm/*.d.ts",
+    "dist/esm/*.js",
+    "dist/es6/*.d.ts",
+    "dist/es6/*.js",
+    "src/*.ts",
+    "src/*.tsx"
+  ],
   "scripts": {
     "build": "tsc --build --incremental tsconfig.build.json",
     "buildProd": "tsc --build tsconfig.build.json",
@@ -18,6 +28,13 @@
     "release:validate": "./scripts/validateRelease.sh TAG=1.2.3",
     "release:publish": "./scripts/publishRelease.sh",
     "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "classnames": "^2.0.0",
+    "invariant": "^2.0.0",
+    "lodash": "^4.0.0",
+    "tslib": "^2.2.0",
+    "uniforms": "^3.5.5"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "7.10.4",
@@ -36,7 +53,6 @@
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
     "babel-eslint": "10.1.0",
-    "classnames": "2.2.6",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "eslint": "6.8.0",
@@ -49,9 +65,7 @@
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-react": "7.22.0",
     "eslint-plugin-vazco": "1.0.0",
-    "invariant": "2.2.4",
     "jest": "25.5.4",
-    "lodash": "4.17.20",
     "prettier": "2.2.1",
     "prop-types": "15.7.2",
     "react": "16.13.1",
@@ -60,12 +74,11 @@
     "simpl-schema": "1.10.2",
     "ts-jest": "25.5.1",
     "ts-node": "8.10.2",
-    "tslib": "2.2.0",
     "typescript": "3.8.3",
-    "uniforms": "3.5.1",
-    "uniforms-bridge-simple-schema-2": "3.5.1"
+    "uniforms-bridge-simple-schema-2": "^3.5.5"
   },
   "peerDependencies": {
+    "react": "^17.0.0 || ^16.8.0",
     "@patternfly/react-core": "^4.135.0",
     "@patternfly/react-icons": "^4.11.0"
   },

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,5 +3,6 @@
   "references": [
     { "path": "tsconfig.es5.json" },
     { "path": "tsconfig.es6.json" },
+    { "path": "tsconfig.esm.json" },
   ]
 }

--- a/tsconfig.es5.json
+++ b/tsconfig.es5.json
@@ -5,5 +5,6 @@
     "outDir": "dist/es5",
     "rootDir": "src",
     "target": "es5",
+    "tsBuildInfoFile": "node_modules/.cache/uniforms-patternfly.es5.tsbuildinfo"
   }
 }

--- a/tsconfig.es6.json
+++ b/tsconfig.es6.json
@@ -5,5 +5,7 @@
     "outDir": "dist/es6",
     "rootDir": "src",
     "target": "es6",
-  }
+    "tsBuildInfoFile": "node_modules/.cache/uniforms-patternfly.es6.tsbuildinfo"
+  },
+  "include": ["src"]
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+ "compilerOptions": {
+    "baseUrl": "src",
+    "outDir": "dist/esm",
+    "rootDir": "src",
+    "target": "es5",
+    "module": "es6",
+    "tsBuildInfoFile": "node_modules/.cache/uniforms-patternfly.esm.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1965,10 +1965,10 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@2.2.6:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+classnames@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -3296,7 +3296,7 @@ internal-slot@^1.0.2:
     has "^1.0.3"
     side-channel "^1.0.2"
 
-invariant@2.2.4, invariant@^2.0.0, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.2:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -4192,7 +4192,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.17.20, lodash@^4.0.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@^4.0.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -5832,11 +5832,6 @@ tslib@1.13.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
-  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
-
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -5928,21 +5923,21 @@ unicode-property-aliases-ecmascript@^1.0.4:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz#dd57a99f6207bedff4628abefb94c50db941c8f4"
   integrity sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
 
-uniforms-bridge-simple-schema-2@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/uniforms-bridge-simple-schema-2/-/uniforms-bridge-simple-schema-2-3.5.1.tgz#03cf6a814de8db98d7f95ec1413e93399ea86d5a"
-  integrity sha512-lYYN9UKXf/B/LNGk5OlEjGOGIB6opw1QcYQiZRMUgUEURHIPHhv732dLoPwLAxA6ZnN0DOo/JEkJMOGzGTzVeg==
+uniforms-bridge-simple-schema-2@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/uniforms-bridge-simple-schema-2/-/uniforms-bridge-simple-schema-2-3.5.5.tgz#408d44972ae6c2dbda1192b048ac4038938a30d5"
+  integrity sha512-moOymizor2E3fyHZfv2MKTs4jTSmqx5GFKTyVUQ4COySeDQTdbEgcMjLm8bcI3CkdUihuuKKllfMpVhdtA793A==
   dependencies:
     invariant "^2.0.0"
     lodash "^4.0.0"
     simpl-schema "^1.0.0 || ^0.0.4"
     tslib "^2.2.0"
-    uniforms "^3.5.1"
+    uniforms "^3.5.5"
 
-uniforms@3.5.1, uniforms@^3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/uniforms/-/uniforms-3.5.1.tgz#7ae798518cc280c60e22cd1077aaa9440e2c6a84"
-  integrity sha512-1N8Y/QB2YSiMJMkwh1iAAzEd2jVDDa5qzL0VynzD8bsaHBB2UhUPUavAitLXK1s+nL76Y472+iMG0p5onQl4hg==
+uniforms@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/uniforms/-/uniforms-3.5.5.tgz#cb8ac5224b1828ca33431e94ad3ad17265cfb5fc"
+  integrity sha512-X5EQnm2CL5KSbu+ZAUua8sIZbzCMXtmSFQf3hTzBQydzYkhy1mm+19OcdrvJJn//Bf8vbUcaycxefZ9qRL4hKA==
   dependencies:
     invariant "^2.0.0"
     lodash "^4.0.0"


### PR DESCRIPTION
This fixes yet again some weird error of mixing `uniforms` versions when used with `uniforms >= 3.5.2`