### PR TITLE
Add direction and appendMenuTo options on SelectField

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -19,7 +19,7 @@
     "uniforms-bridge-json-schema": "3.5.1",
     "uniforms-bridge-simple-schema": "3.5.1",
     "uniforms-bridge-simple-schema-2": "3.5.1",
-    "uniforms-patternfly": "4.7.3"
+    "uniforms-patternfly": "4.7.4"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-patternfly",
-  "version": "4.7.3",
+  "version": "4.7.4",
   "description": "Patternfly forms for uniforms",
   "repository": "git@github.com:aerogear/uniforms-patternfly.git",
   "author": "Gianluca <gzuccare@redhat.com>",

--- a/src/SelectField.tsx
+++ b/src/SelectField.tsx
@@ -1,14 +1,15 @@
-import React, { Ref, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Checkbox,
   CheckboxProps,
   Radio,
   RadioProps,
   Select,
-  SelectProps,
+  SelectDirection,
   SelectOption,
-  SelectVariant,
   SelectOptionObject,
+  SelectProps,
+  SelectVariant
 } from '@patternfly/react-core';
 import { connectField, FieldProps, filterDOMProps } from 'uniforms';
 
@@ -53,6 +54,8 @@ type SelectInputProps = FieldProps<
     disabled?: boolean;
     error?: boolean;
     transform?: (value?: string) => string;
+    direction: SelectDirection;
+    menuAppendTo: HTMLElement;
   }
 >;
 
@@ -199,6 +202,8 @@ function SelectField(props: SelectFieldProps) {
       onToggle={() => setExpanded(!expanded)}
       onSelect={handleSelect}
       value={props.value || (props.fieldType === Array ? [] : undefined)}
+      menuAppendTo={props.menuAppendTo}
+      direction={props.direction}
     >
       {selectedOptions}
     </Select>


### PR DESCRIPTION
This PR adds the option to customize the SelectField so it can be opened in other directions and set the place to append the menu.