### PR TITLE
fix package name typo and bump version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In this example, we will use the JSON Schema to describe our desired data format
 
 ```shell
 npm install uniforms@3.5.1
-npm install uniforms-json-schema-bridge@3.5.1
+npm install uniforms-bridge-json-schema@3.5.1
 npm install uniforms-patternfly
 npm install @patternfly/react-core @patternfly/react-icons
 ```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To start using uniforms, we have to install three independent packages:
 In this example, we will use the JSON Schema to describe our desired data format and style our form using the Pattenfly UI theme.
 
 ```shell
-npm install uniforms@3.5.1
-npm install uniforms-bridge-json-schema@3.5.1
+npm install uniforms@3.6.2
+npm install uniforms-bridge-json-schema@3.6.2
 npm install uniforms-patternfly
 npm install @patternfly/react-core @patternfly/react-icons
 ```
@@ -31,7 +31,7 @@ your `index.html` like in the example app of this repo.
 
 Obs: If you use a previous version of the `tslib` indirectly (version 1), it should be necessary to add this dependency as well.
 ```shell
-npm install tslib@^2.2.0
+npm install tslib@^2.3.1
 ```
 
 ### 2. Start by defining a schema


### PR DESCRIPTION
Changes the README installation instructions from `uniforms-json-schema-bridge` -> `uniforms-bridge-json-schema` and bumps the versions on there.