### PR TITLE
Fix: Filter menuAppendTo props of SelectField

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -19,7 +19,7 @@
     "uniforms-bridge-json-schema": "3.5.1",
     "uniforms-bridge-simple-schema": "3.5.1",
     "uniforms-bridge-simple-schema-2": "3.5.1",
-    "uniforms-patternfly": "4.7.4"
+    "uniforms-patternfly": "4.7.5"
   },
   "devDependencies": {
     "parcel-bundler": "^1.12.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniforms-patternfly",
-  "version": "4.7.4",
+  "version": "4.7.5",
   "description": "Patternfly forms for uniforms",
   "repository": "git@github.com:aerogear/uniforms-patternfly.git",
   "author": "Gianluca <gzuccare@redhat.com>",

--- a/src/wrapField.tsx
+++ b/src/wrapField.tsx
@@ -11,10 +11,19 @@ declare module 'uniforms' {
     checkboxes: never;
     exclusiveMaximum: never;
     exclusiveMinimum: never;
+    menuAppendTo: never;
   }
 }
 
-filterDOMProps.register('decimal', 'minCount', 'autoValue', 'isDisabled', 'exclusiveMaximum', 'exclusiveMinimum');
+filterDOMProps.register(
+  'decimal',
+  'minCount',
+  'autoValue',
+  'isDisabled',
+  'exclusiveMaximum',
+  'exclusiveMinimum',
+  'menuAppendTo'
+);
 
 type WrapperProps = {
   id: string;


### PR DESCRIPTION
Register `menuAppendTo` props to be filter on the `FormGroup` component.

Adding the `menuAppendTo` props on a `SelectField` was causing a `console.error`.